### PR TITLE
Update selector with v0.9.0 binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 _site
 .DS_Store
+.jekyll-cache/

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -24,9 +24,9 @@
           <div class="option-text">TVM Build</div>
         </div>
         <div class="col-md-6 option block version" id="stable">
-          <div class="option-text">0.8.dev107+g7b11b9217</div>
+          <div class="option-text">0.9.0</div>
         </div>
-        <div class="col-md-6 option block version selected" id="preview">
+        <div class="col-md-6 option block version" id="preview">
           <div class="option-text">Nightly</div>
         </div>
       </div>
@@ -48,7 +48,7 @@
         <div class="col-md-12 title-block mobile-heading">
           <div class="option-text">Package</div>
         </div>
-        <div class="col-md-4 option block selected" id="conda">
+        <div class="col-md-4 option block" id="conda">
           <div class="option-text">Conda</div>
         </div>
         <div class="col-md-4 option block" id="pip">
@@ -62,16 +62,16 @@
         <div class="col-md-12 title-block mobile-heading">
           <div class="option-text">CUDA</div>
         </div>
-        <div class="col-md option block version" id="cuda10.0">
-          <div class="option-text">10.0</div>
-        </div>
-        <div class="col-md option block version" id="cuda10.1">
-          <div class="option-text">10.1</div>
-        </div>
         <div class="col-md option block version" id="cuda10.2">
           <div class="option-text">10.2</div>
         </div>
-        <div class="col-md option block version selected" id="cudanone">
+        <div class="col-md option block version" id="cuda11.3">
+          <div class="option-text">11.3</div>
+        </div>
+        <div class="col-md option block version" id="cuda11.6">
+          <div class="option-text">11.6</div>
+        </div>
+        <div class="col-md option block version" id="cudanone">
           <div class="option-text">None</div>
         </div>
       </div>

--- a/js/quick-start-widget.js
+++ b/js/quick-start-widget.js
@@ -8,10 +8,18 @@ var supportedOperatingSystems = new Map([
 var opts = {
   cuda: 'cudanone',
   os: getAnchorSelectedOS() || getDefaultSelectedOS(),
-  pm: 'conda',
+  pm: 'pip',
   language: 'python',
-  tvmbuild: 'preview',
+  tvmbuild: 'stable',
 };
+
+for (const opt in opts) {
+  const value = opts[opt];
+  const el = document.querySelector(`div[id=${value}]`);
+  if (el) {
+    $(el).addClass("selected");
+  }
+}
 
 var os = $(".os > .option");
 var package = $(".package > .option");
@@ -81,7 +89,8 @@ function selectedOption(option, selection, category) {
   if (category === "pm") {
   }
 
-  commandMessage(buildMatcher());
+  const match = buildMatcher();
+  commandMessage(match);
   if (category === "os") {
     display(opts.os, 'installation', 'os');
   }
@@ -148,6 +157,11 @@ function setupMapping() {
       }
     }
   }
+  object["stable,pip,macos,cudanone,python"] = "pip install apache-tvm"
+  object["stable,pip,linux,cudanone,python"] = "pip install apache-tvm"
+  object["stable,pip,linux,cuda10.2,python"] = "pip install apache-tvm-cu102 -f https://tlcpack.ai/wheels"
+  object["stable,pip,linux,cuda11.3,python"] = "pip install apache-tvm-cu113 -f https://tlcpack.ai/wheels"
+  object["stable,pip,linux,cuda11.6,python"] = "pip install apache-tvm-cu116 -f https://tlcpack.ai/wheels"
   return object;
 }
 
@@ -156,7 +170,7 @@ var commandMap = setupMapping();
 function commandMessage(key) {
   if (!commandMap.hasOwnProperty(key)) {
     $("#command").html(
-      "<pre> # Follow instructions at this URL: https://tvm.apache.org/docs/install/from_source.html </pre>"
+      "<pre> # Follow instructions at this URL: <a style=\"font-size: 1em\" href=\"https://tvm.apache.org/docs/install/from_source.html\">https://tvm.apache.org/docs/install/from_source.html</a> </pre>"
     );
   } else {
     $("#command").html("<pre>" + commandMap[key] + "</pre>");

--- a/serve_local.sh
+++ b/serve_local.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm -rf _site
-jekyll serve --watch
+jekyll serve --host 0.0.0.0 --livereload


### PR DESCRIPTION
This changes the stable version to v0.9 and inserts some special cases
for when `apache-tvm` packages can be installed from PyPi
